### PR TITLE
Added popup menu links to tab sets and unread bookmarks pages on pinboard.in

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@ const ADD_LINK_URL = 'https://pinboard.in/add?showtags=yes&url={url}&title={titl
 const READ_LATER_URL = 'https://pinboard.in/add?later=yes&noui=yes&jump=close&url={url}&title={title}';
 const SAVE_TABS_URL = 'https://pinboard.in/tabs/save/';
 const SHOW_TABS_URL = 'https://pinboard.in/tabs/show/';
+const ALL_TABS_URL = "https://pinboard.in/tabs/";
+const UNREAD_BOOKMARKS_URL = "https://pinboard.in/toread/";
 
 var pin_window_id;
 var toolbar_button_state = 'show_menu';
@@ -180,6 +182,18 @@ function message_handler(message) {
                 if (option.show_notifications) {
                     show_notification('Link added to Pinboard');
                 }
+            });
+            break;
+
+        case 'view_all_unread':
+            browser.tabs.create({
+                url: UNREAD_BOOKMARKS_URL
+            });
+            break;
+
+        case 'view_all_tabsets':
+            browser.tabs.create({
+                url: ALL_TABS_URL
             });
             break;
 

--- a/popup_menu.html
+++ b/popup_menu.html
@@ -21,6 +21,9 @@
             <div id="menu-later" class="panel-list-item text">Read later</div>
             <div id="menu-tabset" class="panel-list-item text">Save tab set</div>
             <div class="panel-section-separator"></div>
+            <div id="menu-all-unread" class="panel-list-item text">Unread bookmarks</div>
+            <div id="menu-all-tabsets" class="panel-list-item text">Tab sets</div>
+            <div class="panel-section-separator"></div>
             <div id="menu-preferences" class="panel-list-item text">Preferences</div>
         </div>
     </div>

--- a/popup_menu.js
+++ b/popup_menu.js
@@ -12,6 +12,14 @@ document.addEventListener('DOMContentLoaded', function () {
         browser.runtime.sendMessage({'message': 'save_tab_set'}).then(function () { window.close(); });
     });
 
+    document.getElementById('menu-all-unread').addEventListener('click', function () {
+        browser.runtime.sendMessage({'message': 'view_all_unread'}).then(function () { window.close(); });
+    });
+
+    document.getElementById('menu-all-tabsets').addEventListener('click', function () {
+        browser.runtime.sendMessage({'message': 'view_all_tabsets'}).then(function () { window.close(); });
+    });
+
     document.getElementById('menu-preferences').addEventListener('click', function () {
         browser.runtime.openOptionsPage();
         window.close();


### PR DESCRIPTION
+ Added a second menu separator so these are visually separate from the menu items which 'add' things to pinboard.in (just as the official chrome extension does).
+ The respective pages open in a new tab.

![screen shot 2017-11-27 at 23 12 36](https://user-images.githubusercontent.com/41276/33294446-85c62892-d3c8-11e7-997a-1b489f0d91ef.png)


- Didn't add these links to the context menu, conceptually, not sure they should be there. Or is it better to be consistent with the menu bar popup?